### PR TITLE
Added a scale prop to scale down/Up the SVG size easily

### DIFF
--- a/src/components/AnimatedLogo.tsx
+++ b/src/components/AnimatedLogo.tsx
@@ -17,6 +17,7 @@ interface Props {
   paths: string[];
   vWidth: number;
   vHeight: number;
+  scale: number;
   duration: number;
   strokeWidth: number;
   strokeColor: string;
@@ -30,6 +31,7 @@ const AnimatedLogo = ({
   paths,
   vWidth,
   vHeight,
+  scale,
   duration,
   strokeWidth,
   strokeColor,
@@ -37,8 +39,8 @@ const AnimatedLogo = ({
   isRepeat = false,
   isAnimationFinished,
 }: Props) => {
-  const width = Dimensions.get('window').width - 64;
-  const height = (width * vHeight + margin) / (vWidth + margin);
+  const width = (Dimensions.get('window').width - 64) * scale;
+  const height = ((width * vHeight + margin) / (vWidth + margin)) * scale;
 
   const progress = useSharedValue(0);
 


### PR DESCRIPTION
A simple prop added to scale the SVGs

Example:
```
<AnimatedLogo style={{margin: 100}}
  vWidth={300}
  vHeight={181}
  scale={0.6} // => Here.
  duration={3000}
  strokeWidth={3}
  margin={0}
  strokeColor={'#FFE600'}
  animatedStrokeColor={'#FFE600'}
  isRepeat={true}
  isAnimationFinished={(isFinished) =>
    console.log('Hide splash screen now!', isFinished)
  }
  paths={[
      '',
  ]}
/>
```

Tested & Working!